### PR TITLE
6 feedback from grls implementation

### DIFF
--- a/raritan/context.py
+++ b/raritan/context.py
@@ -124,6 +124,12 @@ class Context(object):
         bad_type = type(name)
         raise RuntimeError(f'Data references may only be gotten by string or list, {bad_type} provided.')
 
+    def clear_data_references(self) -> None:
+        """
+        Empties the data_references storage.
+        """
+        self.data_references = {}
+
     def set_settings_module(self, module_name: str) -> None:
         """
         Sets the ETL settings namespace.

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -157,12 +157,13 @@ def input_data(*args, **kwargs):
                     # Pass them on to the input handler.
                     duration, data = _time_function(settings.input_handler, *[group, name])
                     context.set_data_reference(key, data)
+                    message = ''
                     # Allow an analyze_asset_handler to ensure integrity and/or write the logging.
                     if analyze and hasattr(settings, 'analyze_asset_handler'):
                         message = settings.analyze_asset_handler(group, name, None, data, duration, 'input')
-                        logger.success(message)
-                    else:
-                        logger.success(f'Loaded asset: {name} {duration}')
+                    if message is None or len(message) == 0:
+                        message = f'Loaded asset: {name} {duration}'
+                    logger.success(message)
         return wrapper_function
     # If no arguments are passed to the decorator, return the wrapper one level down.
     if len(args) > 0 and callable(args[0]):
@@ -207,7 +208,7 @@ def output_data(*args, **kwargs):
                         if analyze and hasattr(settings, 'analyze_asset_handler'):
                             message = settings.analyze_asset_handler(group, key, asset_format, data, duration, 'output')
                             logger.success(message)
-                        if len(message) == 0:
+                        if message is None or len(message) == 0:
                             message = f'Finished output: {key} in format {asset_format} {duration}'
                         logger.success(message)
         return wrapper_function

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -64,7 +64,7 @@ def flow(*args, **kwargs):
             start_string = start.strftime('%Y-%m-%d %H:%m:%S')
             logger.info(f'Started: {start_string}')
             try:
-                duration = _time_function(original_function, *args, **kwargs)
+                duration = _time_function(original_function, *args, **kwargs)[0]
                 emoji = random.choice(('cat', 'dog', 'horse', 'gorilla'))
                 logger.success(f'Completed flow run! :{emoji}:')
                 logger.info(f'Total duration {duration}')
@@ -202,7 +202,7 @@ def output_data(*args, **kwargs):
                     for asset_format in asset['formats']:
                         logger.info(f'Beginning output: {key} in format {asset_format}')
                         duration = _time_function(settings.output_handler, *[group, key, asset_format, data],
-                                                  **asset['output_kwargs'])
+                                                  **asset['output_kwargs'])[0]
                         # Allow an analyze_asset_handler to ensure integrity and/or write the logging.
                         message = ''
                         if analyze and hasattr(settings, 'analyze_asset_handler'):
@@ -236,7 +236,7 @@ def _get_file_name_from_function(function: callable) -> str:
     return flow_file[0]
 
 
-def _time_function(func: callable, *args, **kwargs) -> tuple | str:
+def _time_function(func: callable, *args, **kwargs) -> tuple:
     """
     Times the execution of a function.
 
@@ -258,10 +258,7 @@ def _time_function(func: callable, *args, **kwargs) -> tuple | str:
     start = datetime.now()
     output = func(*args, **kwargs)
     end = datetime.now()
-    if output is None:
-        return _get_formatted_duration(start, end)
-    else:
-        return _get_formatted_duration(start, end), output
+    return _get_formatted_duration(start, end), output
 
 
 def _get_formatted_duration(start: datetime, end: datetime) -> str:

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -207,7 +207,6 @@ def output_data(*args, **kwargs):
                         message = ''
                         if analyze and hasattr(settings, 'analyze_asset_handler'):
                             message = settings.analyze_asset_handler(group, key, asset_format, data, duration, 'output')
-                            logger.success(message)
                         if message is None or len(message) == 0:
                             message = f'Finished output: {key} in format {asset_format} {duration}'
                         logger.success(message)

--- a/raritan/test_settings.py
+++ b/raritan/test_settings.py
@@ -10,34 +10,38 @@ A settings file for running the test suite.
 data_dir = './raritan/tests/fixture'
 
 
-def input_handler(file: str, extension: str) -> str:
+def input_handler(path: str, file: str) -> str:
     """
     An input handler for our testing purposes.
 
     Parameters
     ----------
+    path: str
+      The path to the file.
     file: str
       The full path to the resource.
-    extension: str
-      The extension for pivoting handling.
 
     Returns
     -------
     A string in this case, though it could be anything.
     """
-    assert extension == 'txt'
-    with open(f'{file}', 'r') as file:
+    assert '.txt' in file
+    full_path = f'{path}/{file}'
+    assert os.path.isfile(full_path)
+    with open(full_path, 'r') as file:
         return file.read()
 
 
-def output_handler(file: str, extension: str, data: str | dict, **kwargs) -> None:
+def output_handler(path: str, file: str, extension: str, data: str | dict, **kwargs) -> None:
     """
-    An output handler for our testing purposes
+    An output handler for our testing purposes.
 
     Parameters
     ----------
+    path: str
+      The path to the resource.
     file: str
-      The full path to the resource.
+      The name of the item.
     extension: str
       The extension for pivoting handling.
     data: string|dict
@@ -49,9 +53,11 @@ def output_handler(file: str, extension: str, data: str | dict, **kwargs) -> Non
     assert not kwargs.get('fi')
     data_type = type(data)
     if data_type is not dict:
-        _write_file(file, data)
+        if extension not in file:
+            file = f'{file}.{extension}'
+        _write_file(f'{path}/{file}', data)
     elif data_type is dict:
-        directory = os.path.splitext(file)[0]
+        directory = f'{path}/{file}'
         if not os.path.isdir(directory):
             os.mkdir(directory)
         for name, item in data.items():
@@ -76,14 +82,16 @@ def _write_file(name: str, data: str) -> None:
         file.write(data)
 
 
-def analyze_asset_handler(file: str, extension: str, data: str | dict, duration: str, operation: str) -> str:
+def analyze_asset_handler(path: str, file: str, extension: str, data: str | dict, duration: str, operation: str) -> str:
     """
     An analysis handler for our testing purposes.
 
     Parameters
     ----------
+    path: str
+      The path to the resource.
     file: str
-      The full path to the resource.
+      The name of the item.
     extension: str
       The extension for pivoting handling.
     data: str
@@ -99,10 +107,10 @@ def analyze_asset_handler(file: str, extension: str, data: str | dict, duration:
     """
     if type(data) is dict:
         data = json.dumps(data)
-        file = file.replace(extension, 'zip')
+        extension = 'zip'
     checksum = hashlib.sha1(data.encode('utf-8')).hexdigest()
     checksum = checksum[0:10]
     if operation == 'input':
-        return f'Loaded asset {file} {duration} {checksum}'
+        return f'Loaded asset {path}/{file} {duration} {checksum}'
     if operation == 'output':
-        return f'Finished output: {file} {duration} {checksum}'
+        return f'Finished output: {path}/{file}.{extension} {duration} {checksum}'

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -209,6 +209,7 @@ def test_flow_decorator() -> None:
     log_output = capture.get()
     assert 'Beginning flow: test_decorators' in log_output
     assert 'Started' in log_output
+    assert 'Loaded asset' in log_output
     assert 'Beginning task: transform_data' in log_output
     assert 'Completed task: transform_data 1s' in log_output
     assert 'Beginning output: another_fixture in format csv' in log_output

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -81,7 +81,7 @@ def dump_data() -> dict:
     """
     return {
         settings.data_dir: {
-            'finalized_fixture': {
+            'another_fixture': {
                 'formats': ('csv', 'sql'),
                 'output_kwargs': {
                     'fee': True,
@@ -177,30 +177,30 @@ def test_output_decorator() -> None:
     """
     Tests the output decorator both good and bad.
     """
-    context.set_data_reference('finalized_fixture', 'here is the final output')
     with console.capture() as capture:
+        get_data()
         dump_data()
         with pytest.raises(Exception):
             missing_dump_data()
     log_output = capture.get()
     # Test the one to one output.
-    assert 'Beginning output: finalized_fixture in format csv' in log_output
-    assert 'Finished output: ./raritan/tests/fixture/finalized_fixture.csv <1s 321d34bc9a' in log_output
-    assert 'Beginning output: finalized_fixture in format sql' in log_output
-    assert 'Finished output: ./raritan/tests/fixture/finalized_fixture.sql <1s 321d34bc9a' in log_output
+    assert 'Beginning output: another_fixture in format csv' in log_output
+    assert 'Finished output: ./raritan/tests/fixture/another_fixture.csv <1s 9bbb4fc759' in log_output
+    assert 'Beginning output: another_fixture in format sql' in log_output
+    assert 'Finished output: ./raritan/tests/fixture/another_fixture.sql <1s 9bbb4fc759' in log_output
     # Test the many-to-one output.
     assert 'Beginning output: fixture_group in format csv' in log_output
     assert 'Finished output: ./raritan/tests/fixture/fixture_group.zip <1s bc63b64f5a' in log_output
-    assert 'Beginning output: finalized_fixture in format sql' in log_output
+    assert 'Beginning output: different_fixture_group in format csv' in log_output
     assert 'Finished output: ./raritan/tests/fixture/different_fixture_group.zip <1s' in log_output
     assert '8a79d95e42' in log_output
-    assert os.path.isfile(f'{settings.data_dir}/finalized_fixture.csv')
-    assert os.path.isfile(f'{settings.data_dir}/finalized_fixture.sql')
+    assert os.path.isfile(f'{settings.data_dir}/another_fixture.csv')
+    assert os.path.isfile(f'{settings.data_dir}/another_fixture.sql')
     assert os.path.isfile(f'{settings.data_dir}/fixture_group.zip')
     assert os.path.isfile(f'{settings.data_dir}/different_fixture_group.zip')
 
 
-def test_flow_decorator():
+def test_flow_decorator() -> None:
     """
     Tests the flow decorator.
     """
@@ -211,15 +211,22 @@ def test_flow_decorator():
     assert 'Started' in log_output
     assert 'Beginning task: transform_data' in log_output
     assert 'Completed task: transform_data 1s' in log_output
-    assert 'Beginning output: finalized_fixture in format csv' in log_output
-    assert 'Finished output: ./raritan/tests/fixture/finalized_fixture.csv <1s' in log_output
-    assert 'Beginning output: finalized_fixture in format sql' in log_output
-    assert 'Finished output: ./raritan/tests/fixture/finalized_fixture.sql <1s' in log_output
+    assert 'Beginning output: another_fixture in format csv' in log_output
+    assert 'Finished output: ./raritan/tests/fixture/another_fixture.csv <1s' in log_output
+    assert 'Beginning output: another_fixture in format sql' in log_output
+    assert 'Finished output: ./raritan/tests/fixture/another_fixture.sql <1s' in log_output
     assert 'Completed flow run!' in log_output
     assert 'Total duration 1s' in log_output
 
 
-def teardown_function():
+def setup_function() -> None:
+    """
+     Performs setup steps.
+    """
+    context.clear_data_references()
+
+
+def teardown_function() -> None:
     """
     Removes any leftover output files.
     """

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -145,12 +145,12 @@ def test_input_decorator() -> None:
     """
     with console.capture() as capture:
         get_data()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(AssertionError):
             missing_input_data()
     fixture = context.get_data_reference('test_fixture')
     log_output = capture.get()
-    assert 'Handling asset: ./raritan/tests/fixture/test.txt' in log_output
-    assert 'Loaded asset: ./raritan/tests/fixture/test.txt <1s 321d34bc9a'
+    assert 'Handling asset: test.txt' in log_output
+    assert 'Loaded asset: ./raritan/tests/fixture/test.txt <1s 9bbb4fc759'
     assert fixture
     assert 'A tiny fixture for testing IO.' in fixture
 

--- a/raritan/tests/test_duration.py
+++ b/raritan/tests/test_duration.py
@@ -1,0 +1,26 @@
+import datetime
+
+from raritan.decorators import _get_formatted_duration
+
+"""
+Test the duration formatting function.
+"""
+
+
+def test_formatting_some_durations() -> None:
+    """
+    Tests the duration formatter.
+    """
+    start = datetime.datetime.now()
+    end = start + datetime.timedelta(seconds=30)
+    duration = _get_formatted_duration(start, end)
+    assert duration == '30s'
+    end = start + datetime.timedelta(seconds=550)
+    duration = _get_formatted_duration(start, end)
+    assert duration == '9m10s'
+    end = start + datetime.timedelta(seconds=4000)
+    duration = _get_formatted_duration(start, end)
+    assert duration == '1h6m40s'
+    end = start
+    duration = _get_formatted_duration(start, end)
+    assert duration == '<1s'


### PR DESCRIPTION
### Context
Now that we are implementing this codebase in the GRLS ETL there are a few obvious tweaks that should be made.

1. We should try to make @input_data and @output_data more consistent and less biased towards reading and writing to files.
2. We should make the analyze_asset_handler message return optional. That way users aren't forced to create a message, if they don't want to.
3. Fix floats in duration display.

### Changes
This MR makes the arguments passed to the input, output and analyze handlers more consistent. The input decorator no longer presumes we are dealing with files. The input handler should make that decision and assert. It makes the message from the analyze_asset_handler optional and fixes the duration display. Finally, it adjusts the tests and adds test for duration display.

Closes #6 6