### PR TITLE
13 add schema definition for files in input data task

### DIFF
--- a/example/flow.py
+++ b/example/flow.py
@@ -36,6 +36,7 @@ def get_data() -> dict:
         settings.dictionary_dir: {
             'labs_dictionary': {
                 'optional': True,
+                'default_dictionary': {'input': 'string', 'output': 'string'},
                 'file': 'multi_column_dictionary_labs.csv',
             }
         }

--- a/example/flow.py
+++ b/example/flow.py
@@ -36,7 +36,7 @@ def get_data() -> dict:
         settings.dictionary_dir: {
             'labs_dictionary': {
                 'optional': True,
-                'default_dictionary': {'input': 'string', 'output': 'string'},
+                'default_dictionary': pd.DataFrame(columns=['input', 'output']),
                 'file': 'multi_column_dictionary_labs.csv',
             }
         }

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -152,7 +152,7 @@ def input_data(*args, **kwargs):
     analyze = kwargs.get('analyze', True)
     optional_flag = kwargs.get('optional', False)
     filters = kwargs.get('filters', None)
-    default_dictionary = kwargs.get('default_dictionary', pd.DataFrame())
+    default_dictionary = kwargs.get('default_dictionary', dict())
 
     def _input(original_function):
         @wraps(original_function)
@@ -173,7 +173,7 @@ def input_data(*args, **kwargs):
                         # Grab the filters
                         filters = name.get('filters', None)
                         # Grab the dictionary schema
-                        default_dictionary = name.get('default_dictionary', pd.DataFrame())
+                        default_dictionary = name.get('default_dictionary', dict())
                         name = name.get('file')
                     else:
                         inner_optional_flag = optional_flag  # Use the default optional_flag
@@ -186,10 +186,12 @@ def input_data(*args, **kwargs):
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
-                            print("this is default dictionary ", default_dictionary)
-                            data = pd.DataFrame(default_dictionary)
+                            if default_dictionary:
+                                data = pd.DataFrame.from_dict(default_dictionary, orient='index', columns=['dtype'])
+                            else:
+                                error('No default dictionary provided.')
+                                quit()
                             context.set_data_reference(key, data)
-                            context.print_all_data_references()
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)
                     else:

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -4,8 +4,6 @@ import sys
 from datetime import datetime
 from functools import wraps
 
-import pandas as pd
-
 from raritan import logger
 from raritan.context import context
 from raritan.logger import error

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -178,6 +178,7 @@ def input_data(*args, **kwargs):
                     logger.info(f'Handling asset: {name}')
                     # Check the optional flag
                     if not os.path.exists(group + '/' + name):
+                        print("file does not exist")
                         # It is not optional
                         if not inner_optional_flag:
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -183,11 +183,8 @@ def input_data(*args, **kwargs):
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
                             data = pd.DataFrame(default_dictionary)
-                            print("reached here")
                             context.set_data_reference(key, data)
-                            print("passed")
                             context.print_all_data_references()
-                            print("------")
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)
                     else:

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -162,7 +162,6 @@ def input_data(*args, **kwargs):
             settings = context.get_settings()
             # Get the dictionary describing our input data.
             sources = original_function(*args, **kwargs)
-            print(sources.items())
             # Assets are listed in two tiers.
             for group, assets in sources.items():
                 for key, name in assets.items():
@@ -184,12 +183,9 @@ def input_data(*args, **kwargs):
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
-                            print("Start")
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
-                            print("Reached here")
                             if default_dictionary is None:
                                 raise Exception('No default dictionary provided.')
-                            print("passed if")
                             context.set_data_reference(key, default_dictionary)
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -77,7 +77,9 @@ def flow(*args, **kwargs):
                 # After the build is complete we scan the output for `Traceback` and if the key word is found,
                 # it will throw a fail on Jenkins.
                 quit()
+
         return wrapper_function
+
     # If no arguments are passed to the decorator, return the wrapper one level down.
     if len(args) > 0 and callable(args[0]):
         return _flow(args[0])
@@ -125,7 +127,9 @@ def task(*args, **kwargs):
                 # After the build is complete we scan the output for `Traceback` and if the key word is found,
                 # it will throw a fail on Jenkins.
                 quit()
+
         return wrapper_function
+
     # If no arguments are passed to the decorator, return the wrapper one level down.
     if len(args) > 0 and callable(args[0]):
         return _task(args[0])
@@ -179,7 +183,11 @@ def input_data(*args, **kwargs):
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
                             data = pd.DataFrame(default_dictionary)
+                            print("reached here")
                             context.set_data_reference(key, data)
+                            print("passed")
+                            context.print_all_data_references()
+                            print("------")
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)
                     else:
@@ -196,11 +204,12 @@ def input_data(*args, **kwargs):
                         message = ''
                         # Allow an analyze_asset_handler to ensure integrity and/or write the logging.
                         if analyze and hasattr(settings, 'analyze_asset_handler'):
-                            #message = settings.analyze_asset_handler(group, name, None, data, duration, 'input')
+                            message = settings.analyze_asset_handler(group, name, None, data, duration, 'input')
                         if message is None or len(message) == 0:
                             message = f'Loaded asset: {name} {duration}'
                         logger.success(message)
         return wrapper_function
+
     # If no arguments are passed to the decorator, return the wrapper one level down.
     if len(args) > 0 and callable(args[0]):
         return _input(args[0])
@@ -246,7 +255,9 @@ def output_data(*args, **kwargs):
                         if message is None or len(message) == 0:
                             message = f'Finished output: {key} in format {asset_format} {duration}'
                         logger.success(message)
+
         return wrapper_function
+
     if len(args) > 0 and callable(args[0]):
         return _output(args[0])
     return _output

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -183,6 +183,7 @@ def input_data(*args, **kwargs):
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
+                            print("this is default dictionary ", default_dictionary)
                             data = pd.DataFrame(default_dictionary)
                             context.set_data_reference(key, data)
                             context.print_all_data_references()

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -160,6 +160,7 @@ def input_data(*args, **kwargs):
             nonlocal filters  # Declare filters as nonlocal to modify the outer variable
             nonlocal optional_flag  # Declare optional_flag as nonlocal to modify the outer variable
             nonlocal analyze  # Declare optional_flag as nonlocal to modify the outer variable
+            nonlocal default_dictionary  # Declare optional_flag as nonlocal to modify the outer variable
             settings = context.get_settings()
             # Get the dictionary describing our input data.
             sources = original_function(*args, **kwargs)
@@ -172,6 +173,7 @@ def input_data(*args, **kwargs):
                         # Grab the filters
                         filters = name.get('filters', None)
                         name = name.get('file')
+                        default_dictionary = name.get('default_dictionary')
                     else:
                         inner_optional_flag = optional_flag  # Use the default optional_flag
                     logger.info(f'Handling asset: {name}')

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -3,7 +3,7 @@ import random
 import sys
 from datetime import datetime
 from functools import wraps
-
+import pandas as pd
 from raritan import logger
 from raritan.context import context
 from raritan.logger import error
@@ -146,7 +146,7 @@ def input_data(*args, **kwargs):
     analyze = kwargs.get('analyze', True)
     optional_flag = kwargs.get('optional', False)
     filters = kwargs.get('filters', None)
-
+    default_dictionary = kwargs.get('default_dictionary', pd.DataFrame())
     def _input(original_function):
         @wraps(original_function)
         def wrapper_function(*args, **kwargs):
@@ -174,10 +174,11 @@ def input_data(*args, **kwargs):
                         if not inner_optional_flag:
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
                         else:
-                            logger.info(f"Optional file missing: {name}")
-                            continue  # Skip processing if file is optional
+                            logger.info(f"Optional file missing: {name}, using default dictionary.")
+                            data = default_dictionary
                     # Pass them on to the input handler.
-                    duration, data = _time_function(settings.input_handler, *[group, name])
+                    else:
+                        duration, data = _time_function(settings.input_handler, *[group, name])
                     if filters is not None:
                         try:
                             for filter_function, value in filters.items():

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -187,7 +187,8 @@ def input_data(*args, **kwargs):
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
                             if default_dictionary:
-                                data = pd.DataFrame.from_dict(default_dictionary, orient='index', columns=['dtype']).T
+                                data = pd.DataFrame(columns=default_dictionary.keys()).astype(
+                                    {col: dtype for col, dtype in default_dictionary.items()})
                             else:
                                 error('No default dictionary provided.')
                                 quit()

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -162,6 +162,7 @@ def input_data(*args, **kwargs):
             settings = context.get_settings()
             # Get the dictionary describing our input data.
             sources = original_function(*args, **kwargs)
+            print(sources.items())
             # Assets are listed in two tiers.
             for group, assets in sources.items():
                 for key, name in assets.items():

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -187,7 +187,7 @@ def input_data(*args, **kwargs):
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
                             if default_dictionary:
-                                data = pd.DataFrame.from_dict(default_dictionary, orient='index', columns=['dtype'])
+                                data = pd.DataFrame.from_dict(default_dictionary, orient='index', columns=['dtype']).T
                             else:
                                 error('No default dictionary provided.')
                                 quit()

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -3,7 +3,9 @@ import random
 import sys
 from datetime import datetime
 from functools import wraps
+
 import pandas as pd
+
 from raritan import logger
 from raritan.context import context
 from raritan.logger import error
@@ -147,6 +149,7 @@ def input_data(*args, **kwargs):
     optional_flag = kwargs.get('optional', False)
     filters = kwargs.get('filters', None)
     default_dictionary = kwargs.get('default_dictionary', pd.DataFrame())
+
     def _input(original_function):
         @wraps(original_function)
         def wrapper_function(*args, **kwargs):

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -186,12 +186,9 @@ def input_data(*args, **kwargs):
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
-                            if default_dictionary:
-                                data = pd.DataFrame(columns=default_dictionary.keys()).astype(
-                                    {col: dtype for col, dtype in default_dictionary.items()})
-                            else:
+                            if not default_dictionary:
                                 raise Exception('No default dictionary provided.')
-                            context.set_data_reference(key, data)
+                            context.set_data_reference(key, default_dictionary)
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)
                     else:

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -172,8 +172,9 @@ def input_data(*args, **kwargs):
                         inner_optional_flag = name.get('optional', False)
                         # Grab the filters
                         filters = name.get('filters', None)
+                        # Grab the dictionary schema
+                        default_dictionary = name.get('default_dictionary', pd.DataFrame())
                         name = name.get('file')
-                        default_dictionary = name.get('default_dictionary')
                     else:
                         inner_optional_flag = optional_flag  # Use the default optional_flag
                     logger.info(f'Handling asset: {name}')

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -150,7 +150,7 @@ def input_data(*args, **kwargs):
     analyze = kwargs.get('analyze', True)
     optional_flag = kwargs.get('optional', False)
     filters = kwargs.get('filters', None)
-    default_dictionary = kwargs.get('default_dictionary', dict())
+    default_dictionary = kwargs.get('default_dictionary', None)
 
     def _input(original_function):
         @wraps(original_function)
@@ -178,16 +178,13 @@ def input_data(*args, **kwargs):
                     logger.info(f'Handling asset: {name}')
                     # Check the optional flag
                     if not os.path.exists(group + '/' + name):
-                        print("file does not exist")
                         # It is not optional
                         if not inner_optional_flag:
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
-                            print("it went in here")
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
-                            print("what is default dictionary ", default_dictionary)
-                            if not default_dictionary:
+                            if default_dictionary is None:
                                 raise Exception('No default dictionary provided.')
                             context.set_data_reference(key, default_dictionary)
                             message = f'Loaded default dictionary for {name}'

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -184,6 +184,7 @@ def input_data(*args, **kwargs):
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
+                            print("what is default dictionary ", default_dictionary)
                             if not default_dictionary:
                                 raise Exception('No default dictionary provided.')
                             context.set_data_reference(key, default_dictionary)

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -190,8 +190,7 @@ def input_data(*args, **kwargs):
                                 data = pd.DataFrame(columns=default_dictionary.keys()).astype(
                                     {col: dtype for col, dtype in default_dictionary.items()})
                             else:
-                                error('No default dictionary provided.')
-                                quit()
+                                raise Exception('No default dictionary provided.')
                             context.set_data_reference(key, data)
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -180,6 +180,7 @@ def input_data(*args, **kwargs):
                         # It is not optional
                         if not inner_optional_flag:
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
+                        # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
                             data = pd.DataFrame(default_dictionary)

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -183,6 +183,7 @@ def input_data(*args, **kwargs):
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
+                            print("it went in here")
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
                             print("what is default dictionary ", default_dictionary)
                             if not default_dictionary:

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -178,8 +178,8 @@ def input_data(*args, **kwargs):
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
                         else:
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
-                            data = default_dictionary
-                    # Pass them on to the input handler.
+                            data = pd.DataFrame(default_dictionary)
+                            duration = None
                     else:
                         duration, data = _time_function(settings.input_handler, *[group, name])
                     if filters is not None:

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -171,7 +171,7 @@ def input_data(*args, **kwargs):
                         # Grab the filters
                         filters = name.get('filters', None)
                         # Grab the dictionary schema
-                        default_dictionary = name.get('default_dictionary', dict())
+                        default_dictionary = name.get('default_dictionary', None)
                         name = name.get('file')
                     else:
                         inner_optional_flag = optional_flag  # Use the default optional_flag

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -183,9 +183,12 @@ def input_data(*args, **kwargs):
                             raise FileNotFoundError(f"Non-Optional file missing: {name}")
                         # It is optional, using a dictionary provided to make an empty dataframe with column names.
                         else:
+                            print("Start")
                             logger.info(f"Optional file missing: {name}, using default dictionary.")
+                            print("Reached here")
                             if default_dictionary is None:
                                 raise Exception('No default dictionary provided.')
+                            print("passed if")
                             context.set_data_reference(key, default_dictionary)
                             message = f'Loaded default dictionary for {name}'
                             logger.success(message)

--- a/raritan/decorators.py
+++ b/raritan/decorators.py
@@ -191,14 +191,12 @@ def input_data(*args, **kwargs):
                             except Exception as e:
                                 error(f"Something went wrong with the filter function: {e}")  # Log the error message
                                 # We want all the flows to run even if one fails.
-                                # After the build is complete we scan the output for `Traceback` and if the key word is found,
-                                # it will throw a fail on Jenkins.
                                 quit()
                         context.set_data_reference(key, data)
                         message = ''
                         # Allow an analyze_asset_handler to ensure integrity and/or write the logging.
                         if analyze and hasattr(settings, 'analyze_asset_handler'):
-                            message = settings.analyze_asset_handler(group, name, None, data, duration, 'input')
+                            #message = settings.analyze_asset_handler(group, name, None, data, duration, 'input')
                         if message is None or len(message) == 0:
                             message = f'Loaded asset: {name} {duration}'
                         logger.success(message)

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -3,8 +3,6 @@ import os.path
 import re
 from time import sleep
 
-import pytest
-
 from raritan.context import context
 from raritan.decorators import flow, input_data, output_data, task
 from raritan.logger import console, error
@@ -68,11 +66,6 @@ def get_missing_optional_file_with_schema() -> dict:
     """
     return {
         settings.data_dir: {
-            'missing_optional': {
-                'file': 'missing_optional.txt',
-                'optional': True,
-                'default_dictionary': {'input': 'string', 'output': 'string'},
-            },
             'missing_optional_no_default': {
                 'file': 'missing_optional_no_default.txt',
                 'optional': True
@@ -220,9 +213,6 @@ def test_input_dictionary_messages() -> None:
         except Exception as e:
             error(f"Error occurred: {e}")  # Log the exception using the error() function
     log_output = remove_ansi_escape_sequences(capture.get())
-    assert 'Handling asset: missing_optional.txt' in log_output
-    assert 'Optional file missing: missing_optional.txt, using default dictionary.' in log_output
-    assert 'Loaded default dictionary for missing_optional.txt' in log_output
     assert 'Handling asset: missing_optional_no_default.txt' in log_output
     assert 'Optional file missing: missing_optional_no_default.txt, using default' in log_output
     assert 'dictionary.' in log_output

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -220,12 +220,15 @@ def test_input_dictionary_messages() -> None:
         except Exception as e:
             error(f"Error occurred: {e}")  # Log the exception using the error() function
     log_output = remove_ansi_escape_sequences(capture.get())
+    for line in log_output.split('\n'):
+        print(line)
     assert 'Handling asset: missing_optional.txt' in log_output
     assert 'Optional file missing: missing_optional.txt, using default dictionary.' in log_output
     assert 'Loaded default dictionary for missing_optional.txt' in log_output
-    assert "Handling asset: missing_optional_no_default.txt" in log_output
-    assert "Optional file missing: missing_optional_no_default.txt, using default dictionary." in log_output
-    assert "Error occurred: No default dictionary provided." in log_output
+    assert 'Handling asset: missing_optional_no_default.txt' in log_output
+    assert 'Optional file missing: missing_optional_no_default.txt, using default' in log_output
+    assert 'dictionary.' in log_output
+    assert 'Error occurred: No default dictionary provided.' in log_output
 
 
 def test_input_nonoptional_messages() -> None:

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -3,6 +3,8 @@ import os.path
 import re
 from time import sleep
 
+import pandas as pd
+
 from raritan.context import context
 from raritan.decorators import flow, input_data, output_data, task
 from raritan.logger import console, error
@@ -37,7 +39,7 @@ def get_data() -> dict:
     }
 
 
-@input_data
+@input_data(parallel=False)
 def get_missing_nonoptional_file() -> dict:
     """
     Retrieves a dictionary describing assets, including a missing non-optional file.
@@ -54,7 +56,11 @@ def get_missing_nonoptional_file() -> dict:
     }
 
 
-@input_data
+poison_exposure_dictionary = {'input_substance': 'string', 'output_substance': 'string', 'drop': 'Int64', 'resolved': 'Int64'}
+poison_exposure_dictionary_df = pd.DataFrame(columns=poison_exposure_dictionary.keys()).astype(poison_exposure_dictionary)
+
+
+@input_data(parallel=False)
 def get_missing_optional_file_with_schema() -> dict:
     """
     Retrieves a dictionary describing assets, including missing optional files with and without default dictionaries.
@@ -66,9 +72,10 @@ def get_missing_optional_file_with_schema() -> dict:
     """
     return {
         settings.data_dir: {
-            'missing_optional_no_default': {
-                'file': 'missing_optional_no_default.txt',
-                'optional': True
+            'poison_exposure_dictionary': {
+                'optional': True,
+                'file': 'poison_substance_dictionary.csv',
+                'default_dictionary': poison_exposure_dictionary_df
             }
         }
     }

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -3,8 +3,6 @@ import os.path
 import re
 from time import sleep
 
-import pandas as pd
-
 from raritan.context import context
 from raritan.decorators import flow, input_data, output_data, task
 from raritan.logger import console, error
@@ -56,12 +54,8 @@ def get_missing_nonoptional_file() -> dict:
     }
 
 
-poison_exposure_dictionary = {'input_substance': 'string', 'output_substance': 'string', 'drop': 'Int64', 'resolved': 'Int64'}
-poison_exposure_dictionary_df = pd.DataFrame(columns=poison_exposure_dictionary.keys()).astype(poison_exposure_dictionary)
-
-
 @input_data(parallel=False)
-def get_missing_optional_file_with_schema() -> dict:
+def get_missing_optional_file_without_schema() -> dict:
     """
     Retrieves a dictionary describing assets, including missing optional files with and without default dictionaries.
 
@@ -72,10 +66,9 @@ def get_missing_optional_file_with_schema() -> dict:
     """
     return {
         settings.data_dir: {
-            'poison_exposure_dictionary': {
+            'missing_optional': {
                 'optional': True,
-                'file': 'poison_substance_dictionary.csv',
-                'default_dictionary': poison_exposure_dictionary_df
+                'file': 'missing_optional.csv',
             }
         }
     }
@@ -216,13 +209,12 @@ def test_input_dictionary_messages() -> None:
     """
     with console.capture() as capture:  # Place console capture context manager here
         try:
-            get_missing_optional_file_with_schema()
+            get_missing_optional_file_without_schema()
         except Exception as e:
             error(f"Error occurred: {e}")  # Log the exception using the error() function
     log_output = remove_ansi_escape_sequences(capture.get())
-    assert 'Handling asset: missing_optional_no_default.txt' in log_output
-    assert 'Optional file missing: missing_optional_no_default.txt, using default' in log_output
-    assert 'dictionary.' in log_output
+    assert 'Handling asset: missing_optional.csv' in log_output
+    assert 'Optional file missing: missing_optional.csv, using default dictionary.' in log_output
     assert 'Error occurred: No default dictionary provided.' in log_output
 
 

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -220,8 +220,6 @@ def test_input_dictionary_messages() -> None:
         except Exception as e:
             error(f"Error occurred: {e}")  # Log the exception using the error() function
     log_output = remove_ansi_escape_sequences(capture.get())
-    for line in log_output.split('\n'):
-        print(line)
     assert 'Handling asset: missing_optional.txt' in log_output
     assert 'Optional file missing: missing_optional.txt, using default dictionary.' in log_output
     assert 'Loaded default dictionary for missing_optional.txt' in log_output


### PR DESCRIPTION
Allow dictionaries to be used to define files that are optional & not in the folder. This will create an empty dictionary dataframe with the correct schema so it can be populated by the ETL. 