### PR TITLE
16 send non zero exit code

### DIFF
--- a/raritan/context.py
+++ b/raritan/context.py
@@ -28,6 +28,8 @@ class Context(object):
     current_task = None
     # Disable logging/output.
     no_logging = False
+    # Disable logging/output.
+    exit_on_error = True
     # The namespace to find ETL settings.
     settings_module = 'settings'
 
@@ -74,6 +76,17 @@ class Context(object):
             Whether the logger produced by core.logger should produce output.
         """
         self.no_logging = no_logging
+
+    def set_exit_on_error(self, exit_on_error: bool) -> None:
+        """
+        Setter for the exit behavior.
+
+        Parameters
+        ----------
+        exit_on_error: str
+            Whether the system should exit(1) the process on error.
+        """
+        self.exit_on_error = exit_on_error
 
     def set_data_reference(self, name: str, data_source) -> None:
         """

--- a/raritan/logger.py
+++ b/raritan/logger.py
@@ -90,8 +90,10 @@ def error(message, **kwargs) -> None:
         last_file_line, next_line = get_last_file_and_next_line(traceback_part)
         console.print("------------", style='red')
         console.print(last_file_line, style='red')
-        console.print(f"{message}", style='red')
+        console.print(f"Error occurred: {message}", style='red')
         console.print("Corrupt Code:", next_line, style='red')
         console.print("Variables")
         console.print(context.print_all_data_references(), style='red')
         console.print("------------", style='red')
+    if context.exit_on_error:
+        exit(1)

--- a/raritan/tests/test_decorators.py
+++ b/raritan/tests/test_decorators.py
@@ -13,6 +13,7 @@ Tests decorators and other basic functionality.
 
 # Load the test settings module.
 context.set_settings_module('raritan.test_settings')
+context.set_exit_on_error(False)
 
 settings = context.get_settings()
 
@@ -54,7 +55,7 @@ def get_missing_nonoptional_file() -> dict:
     }
 
 
-@input_data(parallel=False)
+@input_data
 def get_missing_optional_file_without_schema() -> dict:
     """
     Retrieves a dictionary describing assets, including missing optional files with and without default dictionaries.
@@ -208,10 +209,7 @@ def test_input_dictionary_messages() -> None:
         If the expected error messages are not found in the log output.
     """
     with console.capture() as capture:  # Place console capture context manager here
-        try:
-            get_missing_optional_file_without_schema()
-        except Exception as e:
-            error(f"Error occurred: {e}")  # Log the exception using the error() function
+        get_missing_optional_file_without_schema()
     log_output = remove_ansi_escape_sequences(capture.get())
     assert 'Handling asset: missing_optional.csv' in log_output
     assert 'Optional file missing: missing_optional.csv, using default dictionary.' in log_output
@@ -230,10 +228,7 @@ def test_input_nonoptional_messages() -> None:
         AssertionError: If the expected log messages are not found in the captured output.
     """
     with console.capture() as capture:  # Place console capture context manager here
-        try:
-            get_missing_nonoptional_file()
-        except Exception as e:
-            error(f"Error occurred: {e}")  # Log the exception using the error() function
+        get_missing_nonoptional_file()
     log_output = remove_ansi_escape_sequences(capture.get())
     assert 'Handling asset: missing_nonoptional.csv' in log_output
     # Check if the log message "Non-Optional file missing: missing_nonoptional.csv" is present


### PR DESCRIPTION
I refactored the logger.error function to optionally exit with a 1. This is controllable via the context object. I then changed all the decorators to use this function when an error occurs. This makes sure we get consistent behavior and formatting of those errors, while also exiting properly. I also updated the tests to disable this new flag.